### PR TITLE
Add ACK/NACK bytes for SLCAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 
 # SOURCES: list of sources in the user application
-SOURCES = main.c system.c usbd_conf.c usbd_cdc_if.c usb_device.c usbd_desc.c interrupts.c system_stm32f0xx.c can.c slcan.c led.c
+SOURCES = main.c system.c usbd_conf.c usbd_cdc_if.c usb_device.c usbd_desc.c interrupts.c system_stm32f0xx.c can.c slcan.c led.c usb.c
 
 # Get git version and dirty flag
 GIT_VERSION := $(shell git describe --abbrev=7 --dirty --always --tags)

--- a/inc/usb.h
+++ b/inc/usb.h
@@ -1,0 +1,9 @@
+#ifndef _USB_H_
+#define _USB_H_
+
+#include <stdint.h>
+
+void usb_queue_msg_tx_from_interrupt(const uint8_t* msg, uint32_t len);
+void usb_flush();
+
+#endif /* end of include guard: _USB_H_ */

--- a/src/slcan.c
+++ b/src/slcan.c
@@ -6,7 +6,7 @@
 #include "can.h"
 #include "slcan.h"
 #include "string.h"
-#include "usbd_cdc_if.h"
+#include "usb.h"
 
 
 // Parse an incoming CAN frame into an outgoing slcan message
@@ -80,7 +80,7 @@ int8_t slcan_parse_frame(uint8_t *buf, CanRxMsgTypeDef *frame)
 }
 
 
-// Parse an incoming slcan command from the USB CDC port
+// Parse an incoming slcan command from the USB CDC port and transmit it
 int8_t slcan_parse_str(uint8_t *buf, uint8_t len)
 {
     CanTxMsgTypeDef frame;
@@ -175,7 +175,7 @@ int8_t slcan_parse_str(uint8_t *buf, uint8_t len)
     } else if (buf[0] == 'v' || buf[0] == 'V') {
         // Report firmware version and remote
         char* fw_id = GIT_VERSION " " GIT_REMOTE "\r";
-        CDC_Transmit_FS((uint8_t*)fw_id, strlen(fw_id));
+        usb_queue_msg_tx_from_interrupt((uint8_t*)fw_id, strlen(fw_id));
         return 0;
 
     } else if (buf[0] == 't' || buf[0] == 'T') {

--- a/src/usb.c
+++ b/src/usb.c
@@ -1,0 +1,37 @@
+//
+// usb: provides methods to queue data for USB safely
+//
+
+#include "usb.h"
+#include "usbd_cdc_if.h"
+#include "slcan.h"
+
+#define BUFFER_SIZE 128
+
+typedef struct {
+  uint8_t data[BUFFER_SIZE];
+  volatile size_t len;
+  volatile int flushing;
+} data_buffer;
+
+static data_buffer buf;
+
+void usb_queue_msg_tx_from_interrupt(const uint8_t* msg, uint32_t len)
+{
+  if (!buf.flushing && buf.len + len < sizeof(buf.data))
+  {
+    memcpy(buf.data + buf.len, msg, len);
+    buf.len += len;
+  }
+}
+
+void usb_flush()
+{
+  if (buf.len)
+  {
+    buf.flushing = 1;
+    CDC_Transmit_FS(buf.data, buf.len);
+    buf.len = 0;
+    buf.flushing = 0;
+  }
+}

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -50,6 +50,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_cdc_if.h"
 #include "slcan.h"
+#include "usb.h"
 
 /* USER CODE BEGIN INCLUDE */
 
@@ -308,15 +309,16 @@ static int8_t CDC_Receive_FS (uint8_t* Buf, uint32_t *Len)
 
     for (i = 0; i < n; i++)
     {
+       // Check for end of slcan command
        if (Buf[i] == '\r') {
            int result = slcan_parse_str(slcan_str, slcan_str_index);
 
            // Success
-           //if(result == 0)
-           //    CDC_Transmit_FS("\n", 1); 
+           if(result == 0)
+              usb_queue_msg_tx_from_interrupt((uint8_t*)"\r", 1); 
            // Failure
-           //else
-           //    CDC_Transmit_FS("\a", 1);
+           else
+              usb_queue_msg_tx_from_interrupt((uint8_t*)"\a", 1);
 
            slcan_str_index = 0;
        } else {


### PR DESCRIPTION
This fixes issue #8 and allows the adapter to work with UAVCAN.

The problem with the original ACK/NACK implementation seemed to be that if the CANable was in the middle of sending data over USB in the main loop and we got an interrupt, the interrupt would stomp over the in progress transfer causing bad things to happen. Moving all USB transfers into the main loop by storing the data in a buffer in interrupt context and polling when that buffer has something to send fixes this issue. 