### PR TITLE
github action showing that source code in fact compiles

### DIFF
--- a/.github/provide_gcc.sh
+++ b/.github/provide_gcc.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Download and extract GCC arm-none-eabi toolchain
+
+set -e
+
+# URL to download original toolchain from
+URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
+# This is the md5sum of the /bin/arm-none-eabi-ld executable within the archive, used for verifying we have the proper version.
+# If you change the above URL, you will need to update this checksum as well.
+MANIFEST_SUM="8e50ee1adb41acfd56fc38d74d6bb18e"
+# colloquial directory name, to afford re-use of script
+COLLOQUIAL="gcc-arm-none-eabi"
+# temporary working directory
+TMP_DIR="/tmp/rusefi-provide_gcc"
+
+archive="${URL##*/}"
+
+SWD="$PWD"
+
+# If the checksum file doesn't exist, or if its checksum doesn't match, then download and install the archive.
+if [ ! -f "${TMP_DIR}"/*/bin/arm-none-eabi-ld ] ||\
+   [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/bin/arm-none-eabi-ld | cut -d ' ' -f 1)" ]; then
+	rm -rf "${TMP_DIR}"
+	# Download and extract archive
+	echo Downloading and extracting ${archive}
+	mkdir -p "${TMP_DIR}"
+	cd "${TMP_DIR}"
+	curl -L -o "${archive}" "${URL}"
+	tar -xaf "${archive}"
+	rm "${archive}"
+else
+	echo "Toolkit already present"
+fi
+
+# Create colloquially named link
+cd "$SWD"
+ln -sf "${TMP_DIR}"/* "${COLLOQUIAL}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Firmware at GHA
+
+on: [ push, pull_request ]
+
+jobs:
+  build-firmware:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      # Build machines don't have arm-none-eabi gcc, so let's download it and put it on the path
+      - name: Download & Install GCC
+        if: ${{ env.skip != 'true' }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        run: |
+          bash .github/provide_gcc.sh
+          echo "::add-path::`pwd`/gcc-arm-none-eabi/bin"
+
+      - name: Compile
+        run: |
+          make -j


### PR DESCRIPTION
if this is acceptable next step could be to attach build artifacts

also same approach could be used to compile using a few different versions of GCC

here gcc binaries are hosted at github itself well, mostly just to reduce arm servers hit